### PR TITLE
Some small fixes

### DIFF
--- a/src/DICOM.jl
+++ b/src/DICOM.jl
@@ -295,7 +295,7 @@ function element(st, evr, dcm)
     
     vr == "AS" ? ASCIIString(read(st,Uint8,4)) :
     
-    vr == "DS" ? map(integer, string_parse(st, sz, 16, false)) :
+    vr == "DS" ? map(parsefloat, string_parse(st, sz, 16, false)) :
     vr == "IS" ? map(integer, string_parse(st, sz, 12, false)) :
     
     vr == "AE" ? string_parse(st, sz, 16, false) :


### PR DESCRIPTION
Here are a few fixes for DICOM.jl.

Reading sequences was pretty broken, since `sequence_item` didn't actually check how many bytes it read, and `sequence_parse` didn't include the 8 bytes preceding each item in calculating how many bytes had been read. The fix for `sequence_item` is the minimal possible change to the file, but relying on `position` is a bit kludgy.

DICOM.jl was also applying `integer` to the contents of VR `DS` (Decimal String); I changed it to apply `parsefloat`.
