### PR TITLE
add tag macro

### DIFF
--- a/src/DICOM.jl
+++ b/src/DICOM.jl
@@ -1,6 +1,22 @@
 module DICOM
 
 export dcm_parse, dcm_write, lookup, lookup_vr
+export @tag_str
+
+"""
+    @tag_str(s)
+
+Return the dicom tag, corresponding to the string `s`.
+```jldoctest
+julia> using DICOM
+
+julia> tag"ROI Mean"
+(0x6000, 0x1302)
+```
+"""
+macro tag_str(s)
+    DICOM.fieldname_dict[s]
+end
 
 include("dcm_dict.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -154,3 +154,16 @@ dcmMR_multiframe = dcm_parse(fileMR_multiframe)
 
     @test dcmMR_multiframe[(0x0008,0x0060)] == "MR"
 end
+
+@testset "tag" begin
+    @test tag"Modality"                 === (0x0008, 0x0060) ===
+        DICOM.fieldname_dict["Modality"]
+    @test tag"Shutter Overlay Group"    === (0x0018, 0x1623) ===
+        DICOM.fieldname_dict["Shutter Overlay Group"]
+    @test tag"Histogram Last Bin Value" === (0x0060, 0x3006)
+        DICOM.fieldname_dict["Histogram Last Bin Value"]
+
+    # test that compile time error is thrown if tag does not exist
+    @test macroexpand(Main,:(tag"Modality")) === (0x0008, 0x0060)
+    @test_throws LoadError macroexpand(Main,:(tag"nonsense"))
+end


### PR DESCRIPTION
The macro has two benefits:
* It is nice to read
* It detects spelling errors at parse time