### PR TITLE
Remove Julia 1.3 from Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ os:
   - windows
 julia:
   - '1.0'
-  - '1.3'
   - '1'
   - 'nightly'
 matrix:


### PR DESCRIPTION
Julia 1.3 doesn't need to be in the tests. 
It was added when Julia 1.3 was the latest version and I didn't know that the version `'1'` would always use the latest release.
