### PR TITLE
collect DICOM files based on magic bytes

### DIFF
--- a/src/DICOM.jl
+++ b/src/DICOM.jl
@@ -136,7 +136,7 @@ function find_dicom_files(dir)
 end
 
 function isdicom(file)
-    bytes = read(f, 132)[end-3:end]
+    bytes = read(file, 132)[end-3:end]
     String(bytes) == "DICM"
 end
 

--- a/src/DICOM.jl
+++ b/src/DICOM.jl
@@ -135,7 +135,10 @@ function find_dicom_files(dir)
     return dicom_files
 end
 
-isdicom(file) = last(splitext(file)) == ".dcm"
+function isdicom(file)
+    bytes = read(f, 132)[end-3:end]
+    String(bytes) == "DICM"
+end
 
 function dcmdir_parse(dir; kwargs...)
     dicom_files = find_dicom_files(dir)


### PR DESCRIPTION
According to the DICOM standard [1], every DICOM file should has the characters "DICM" as their magic bytes.
This should be more reliable than checking the file extensions.

[1] http://dicom.nema.org/medical/dicom/current/output/chtml/part10/chapter_7.html#table_7.1-1