### PR TITLE
Update version: 0.6.3 -> 0.7.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DICOM"
 uuid = "a26e6606-dd52-5f6a-a97f-4f611373d757"
-version = "0.6.3"
+version = "0.7.0"
 
 [compat]
 julia = "0.7, 1"


### PR DESCRIPTION
Incrementing by a major version because a few of the fieldnames have changed due to #63 
Specifically, some fieldnames contained a parenthesis which is now removed. For example, `dcm[tag"Image Orientation (Patient)"]` would have to be changed to `dcm[tag"Image Orientation Patient"]`.