### PR TITLE
Support 32-bit pixel representations

### DIFF
--- a/src/DICOM.jl
+++ b/src/DICOM.jl
@@ -501,8 +501,12 @@ function determine_dtype(dcm, vr = "OB")
     end
     if bit_type == 8
         dtype = is_signed ? Int8 : UInt8
-    else
+    elseif bit_type == 16
         dtype = is_signed ? Int16 : UInt16
+    elseif bit_type == 32
+        dtype = is_signed ? Int32 : UInt32
+    else
+        error("Unsupported bit_type: $bit_type")
     end
     return dtype
 end


### PR DESCRIPTION
I have an RT Dose file with 32-bit pixel data, which is currently incorrectly interpreted as having 16-bit data. This change fixes it and adds an error in case `bit_type` has an unsupported value.