### PR TITLE
Ignore non-DICOM files in a directory

### DIFF
--- a/src/DICOM.jl
+++ b/src/DICOM.jl
@@ -140,7 +140,7 @@ function isdicom(file)
         bytes = read(file, 132)[end-3:end]
         String(bytes) == "DICM"
     catch
-        not_dicom == true
+        println("not a dicom file")
     end
 end
 

--- a/src/DICOM.jl
+++ b/src/DICOM.jl
@@ -131,16 +131,27 @@ always_implicit(grp, elt) =
 
 function find_dicom_files(dir)
     files = joinpath.(dir, readdir(dir))
+    dicom_files = []
+    # for file in 1:length(files)
+    #     if isdicom(file)
+    #         push!(dicom_files, file)
+    #     end
+    # end
     dicom_files = filter(file -> isdicom(file), files)
     return dicom_files
 end
+
+# function isdicom(file)
+#     bytes = read(file, 132)[end-3:end]
+#     String(bytes) == "DICM"
+# end
 
 function isdicom(file)
     try
         bytes = read(file, 132)[end-3:end]
         String(bytes) == "DICM"
     catch
-        println("not a dicom file")
+        false
     end
 end
 

--- a/src/DICOM.jl
+++ b/src/DICOM.jl
@@ -131,20 +131,9 @@ always_implicit(grp, elt) =
 
 function find_dicom_files(dir)
     files = joinpath.(dir, readdir(dir))
-    dicom_files = []
-    # for file in 1:length(files)
-    #     if isdicom(file)
-    #         push!(dicom_files, file)
-    #     end
-    # end
     dicom_files = filter(file -> isdicom(file), files)
     return dicom_files
 end
-
-# function isdicom(file)
-#     bytes = read(file, 132)[end-3:end]
-#     String(bytes) == "DICM"
-# end
 
 function isdicom(file)
     try

--- a/src/DICOM.jl
+++ b/src/DICOM.jl
@@ -136,8 +136,12 @@ function find_dicom_files(dir)
 end
 
 function isdicom(file)
-    bytes = read(file, 132)[end-3:end]
-    String(bytes) == "DICM"
+    try
+        bytes = read(file, 132)[end-3:end]
+        String(bytes) == "DICM"
+    catch
+        not_dicom == true
+    end
 end
 
 function dcmdir_parse(dir; kwargs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -226,9 +226,19 @@ end
 @testset "Parse entire folder" begin
     # Following files have missing preamble and won't be parsed
     # ["OT_Implicit_Little_Headless.dcm", "CT_Implicit_Little_Headless_Retired.dcm"]
+    # and brain.bpm is not a DICOM file
     dcms = dcmdir_parse(data_folder)
     @test issorted([dcm[tag"Instance Number"] for dcm in dcms])
-    @test length(dcms) == length(readdir(data_folder)) - 2 # -2 because of note above
+    @test length(dcms) == length(readdir(data_folder)) - 3 # -3 because of note above
+end
+
+@testset "isdicom" begin
+    answer = DICOM.isdicom("test/testdata/brain.bmp")
+    @test answer === nothing
+
+    fileDX = download_dicom("DX_Implicit_Little_Interleaved.dcm")
+    answer2 = DICOM.isdicom(fileDX)
+    @test answer2 == true
 end
 
 @testset "Test tag macro" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -232,14 +232,14 @@ end
     @test length(dcms) == length(readdir(data_folder)) - 3 # -3 because of note above
 end
 
-@testset "isdicom" begin
-    answer = DICOM.isdicom("test/testdata/brain.bmp")
-    @test answer === nothing
+# @testset "isdicom" begin
+#     answer = DICOM.isdicom("test/testdata/brain.bmp")
+#     @test answer === nothing
 
-    fileDX = download_dicom("DX_Implicit_Little_Interleaved.dcm")
-    answer2 = DICOM.isdicom(fileDX)
-    @test answer2 == true
-end
+#     fileDX = download_dicom("DX_Implicit_Little_Interleaved.dcm")
+#     answer2 = DICOM.isdicom(fileDX)
+#     @test answer2 == true
+# end
 
 @testset "Test tag macro" begin
     @test tag"Modality" === (0x0008, 0x0060) === DICOM.fieldname_dict[:Modality]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -232,14 +232,14 @@ end
     @test length(dcms) == length(readdir(data_folder)) - 3 # -3 because of note above
 end
 
-# @testset "isdicom" begin
-#     answer = DICOM.isdicom("test/testdata/brain.bmp")
-#     @test answer === nothing
+@testset "isdicom" begin
+    answer = DICOM.isdicom("test/testdata/brain.bmp")
+    @test answer === false
 
-#     fileDX = download_dicom("DX_Implicit_Little_Interleaved.dcm")
-#     answer2 = DICOM.isdicom(fileDX)
-#     @test answer2 == true
-# end
+    fileDX = download_dicom("DX_Implicit_Little_Interleaved.dcm")
+    answer2 = DICOM.isdicom(fileDX)
+    @test answer2 == true
+end
 
 @testset "Test tag macro" begin
     @test tag"Modality" === (0x0008, 0x0060) === DICOM.fieldname_dict[:Modality]


### PR DESCRIPTION
This PR allows `dcmdir_parse` to work in a directory with non-DICOM-related files. Currently, mac users will run into problems due to `.DS_Store` and `Icon` metadata files. This PR modifies `isdicom` to account for that.

```julia
function isdicom(file)
    try
        bytes = read(file, 132)[end-3:end]
        String(bytes) == "DICM"
    catch
        false
    end
end
```

A test and a non-DICOM image were also added to make sure `isdicom` is working properly

```julia
@testset "isdicom" begin
    answer = DICOM.isdicom("test/testdata/brain.bmp")
    @test answer === false

    fileDX = download_dicom("DX_Implicit_Little_Interleaved.dcm")
    answer2 = DICOM.isdicom(fileDX)
    @test answer2 == true
end
```