### PR TITLE
Pass aux_vr to SQ elements in dcm_write

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
-          - '1'
-          - 'nightly'
+          - "1"
+          - "nightly"
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,13 @@
 name = "DICOM"
 uuid = "a26e6606-dd52-5f6a-a97f-4f611373d757"
-version = "0.10.1"
+version = "0.11.0"
 
 [compat]
-julia = "0.7, 1"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Downloads"]

--- a/src/DICOM.jl
+++ b/src/DICOM.jl
@@ -658,10 +658,10 @@ function dcm_store(st::IO, gelt::Tuple{UInt16,UInt16}, writef::Function, vr::Str
         sz += 1
     end
     seek(st, p)
-    write(st, convert(lentype, max(0, sz)))
+    vr == "SQ" || gelt == (0xFFFE, 0xE000) ? write(st, convert(lentype, 0xffffffff)) : write(st, convert(lentype, max(0, sz)))
     seek(st, endp)
     if szWasOdd
-        write(st, UInt8(0))
+        vr in ("AE", "CS", "SH", "LO", "PN", "DA", "DT", "TM") ? write(st, UInt8(0x20)) : write(st, UInt8(0))
     end
 end
 

--- a/src/DICOM.jl
+++ b/src/DICOM.jl
@@ -592,7 +592,7 @@ function write_element(st::IO, gelt::Tuple{UInt16,UInt16}, data, is_explicit, au
 
     if vr == "SQ"
         vr = is_explicit ? vr : empty_vr
-        return dcm_store(st, gelt, s -> sequence_write(s, map(d -> d.meta, data), is_explicit), vr)
+        return dcm_store(st, gelt, s -> sequence_write(s, map(d -> d.meta, data), is_explicit, aux_vr), vr)
     end
 
     # Pack data into array container. This is to undo "data = data[1]" from read_element().
@@ -665,20 +665,20 @@ function dcm_store(st::IO, gelt::Tuple{UInt16,UInt16}, writef::Function, vr::Str
     end
 end
 
-sequence_write(st::IO, items::Array{Any,1}, evr::Bool) =
-    sequence_write(st, convert(Array{Dict{Tuple{UInt16,UInt16},Any},1}, items), evr)
-function sequence_write(st::IO, items::Array{Dict{Tuple{UInt16,UInt16},Any},1}, evr)
+sequence_write(st::IO, items::Array{Any,1}, evr::Bool, aux_vr::Dict{Tuple{UInt16, UInt16}}) =
+    sequence_write(st, convert(Array{Dict{Tuple{UInt16,UInt16},Any},1}, items), evr, aux_vr)
+function sequence_write(st::IO, items::Array{Dict{Tuple{UInt16,UInt16},Any},1}, evr, aux_vr::Dict{Tuple{UInt16, UInt16}})
     for subitem in items
         if length(subitem) > 0
-            dcm_store(st, (0xFFFE, 0xE000), s -> sequence_item_write(s, subitem, evr))
+            dcm_store(st, (0xFFFE, 0xE000), s -> sequence_item_write(s, subitem, evr, aux_vr))
         end
     end
     write(st, UInt16[0xFFFE, 0xE0DD, 0x0000, 0x0000])
 end
 
-function sequence_item_write(st::IO, items::Dict{Tuple{UInt16,UInt16},Any}, evr)
+function sequence_item_write(st::IO, items::Dict{Tuple{UInt16,UInt16},Any}, evr, aux_vr::Dict{Tuple{UInt16, UInt16}})
     for gelt in sort(collect(keys(items)))
-        write_element(st, gelt, items[gelt], evr, empty_dcm_dict)
+        write_element(st, gelt, items[gelt], evr, aux_vr)
     end
     write(st, UInt16[0xFFFE, 0xE00D, 0x0000, 0x0000])
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Test
 using DICOM
+using Downloads
 
 const data_folder = joinpath(@__DIR__, "testdata")
 if !isdir(data_folder)
@@ -25,8 +26,8 @@ const dicom_samples = Dict(
         "https://github.com/notZaki/DICOMSamples/raw/master/DICOMSamples/OT_Implicit_Little_Headless.dcm",
     "US_Explicit_Big_RGB.dcm" =>
         "https://github.com/notZaki/DICOMSamples/raw/master/DICOMSamples/US_Explicit_Big_RGB.dcm",
-    # "DX_Implicit_Little_Interleaved.dcm" =>
-    #    "https://github.com/OHIF/viewer-testdata/raw/master/dcm/zoo-exotic/5.dcm",
+    "DX_Implicit_Little_Interleaved.dcm" =>
+        "https://github.com/notZaki/DICOMSamples/raw/master/DICOMSamples/DX_Implicit_Little_Interleaved.dcm",
 )
 
 function download_dicom(filename; folder = data_folder)
@@ -34,7 +35,7 @@ function download_dicom(filename; folder = data_folder)
     url = dicom_samples[filename]
     filepath = joinpath(folder, filename)
     if !isfile(filepath)
-        download(url, filepath)
+        Downloads.download(url, filepath)
     end
     return filepath
 end
@@ -185,13 +186,11 @@ end
     @test size(dcmUS[(0x7fe0, 0x0010)]) == (480, 640, 3)
 end
 
-#==
 @testset "Test interleaved" begin
     fileDX = download_dicom("DX_Implicit_Little_Interleaved.dcm")
     dcmDX = dcm_parse(fileDX)
     @test size(dcmDX[(0x7fe0, 0x0010)]) == (1590, 2593, 3)
 end
-==#
 
 @testset "Test Compressed" begin
     fileCT = download_dicom("CT_JPEG70.dcm")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -273,3 +273,37 @@ end
     @test dcmMG3[(0x0008, 0x2218)][1][(0x0008, 0x0104)] == 0x0001
     @test dcmMG3[(0x0054, 0x0220)][1][(0x0008, 0x0104)] == 0x0002
 end
+
+function write_to_string(writef)
+    io = IOBuffer()
+    writef(io)
+    return String(take!(io))
+end
+
+@testset "Padding string values" begin
+    empty_vr_dict = Dict{Tuple{UInt16, UInt16}, String}()
+    # Test that UI strings are padded with '\0' to even length
+    SOPClassUID = write_to_string(io -> DICOM.write_element(io, (0x0008, 0x0016), "1.2.840.10008.5.1.4.1.1.4", true, empty_vr_dict))
+    @test length(SOPClassUID) % 2 == 0
+    @test SOPClassUID[end] == '\0'
+    # Test that SH strings are padded with ' ' to even length
+    StudyDescription = write_to_string(io -> DICOM.write_element(io, (0x0008, 0x1030), "BestImageEver", true, empty_vr_dict))
+    @test length(StudyDescription) % 2 == 0
+    @test StudyDescription[end] == ' '
+end
+
+@testset "Writing Sequence" begin
+    empty_vr_dict = Dict{Tuple{UInt16, UInt16}, String}()
+    # Setup internal SQ DICOMData
+    sq_meta = Dict{Tuple{UInt16, UInt16}, Any}([(0x0008, 0x0100) => "UNDEFINED", (0x0008, 0x010b) => 'N', (0x0008, 0x0104) => "UNDEFINED"])
+    sq_el = DICOM.DICOMData(sq_meta, :little, true, empty_vr_dict)
+
+    # Setup external SQ DICOMData
+    meta = Dict{Tuple{UInt16, UInt16}, Any}((0x0040, 0x0260) => [sq_el])
+    el = DICOM.DICOMData(meta, :little, true, empty_vr_dict)
+
+    PerformedProtocolSequence = write_to_string(io -> DICOM.write_element(io, (0x0040, 0x0260), el[(0x0040, 0x0260)], true, empty_vr_dict))
+    # Check that the length is (0xffffffff) for undefined length SQ
+    @test PerformedProtocolSequence[9:12] == "\xff\xff\xff\xff"
+    @test PerformedProtocolSequence[end-7:end] == "\xfe\xff\xdd\xe0\x00\x00\x00\x00"
+end


### PR DESCRIPTION
- Ensure that auxilliary VR provided by the user is passed when writing all tags including the ones in sequences. This can be used to write private tags and provide VR when multiple are possible (See #87).

- Deactivate tests for non-available file (`DX_Implicit_Little_Interleaved`)
- Add a test where the VR type of a tag within a sequence is changed when written.