### PR TITLE
Fix padding value for IS and DS vrs

### DIFF
--- a/src/DICOM.jl
+++ b/src/DICOM.jl
@@ -676,7 +676,7 @@ function dcm_store(st::IO, gelt::Tuple{UInt16,UInt16}, writef::Function, vr::Str
     vr == "SQ" || gelt == (0xFFFE, 0xE000) ? write(st, convert(lentype, 0xffffffff)) : write(st, convert(lentype, max(0, sz)))
     seek(st, endp)
     if szWasOdd
-        vr in ("AE", "CS", "SH", "LO", "PN", "DA", "DT", "TM") ? write(st, UInt8(0x20)) : write(st, UInt8(0))
+        vr in ("AE", "CS", "SH", "LO", "PN", "DA", "DT", "TM", "IS", "DS") ? write(st, UInt8(0x20)) : write(st, UInt8(0))
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -285,10 +285,16 @@ end
     SOPClassUID = write_to_string(io -> DICOM.write_element(io, (0x0008, 0x0016), "1.2.840.10008.5.1.4.1.1.4", true, empty_vr_dict))
     @test length(SOPClassUID) % 2 == 0
     @test SOPClassUID[end] == '\0'
+
     # Test that SH strings are padded with ' ' to even length
     StudyDescription = write_to_string(io -> DICOM.write_element(io, (0x0008, 0x1030), "BestImageEver", true, empty_vr_dict))
     @test length(StudyDescription) % 2 == 0
     @test StudyDescription[end] == ' '
+    
+    # Test that DS strings are padded with ' ' to even length
+    PixelSpacing = write_to_string(io -> DICOM.write_element(io, (0x0028, 0x0030), [0.5, 0.5], true, empty_vr_dict))
+    @test length(PixelSpacing) % 2 == 0
+    @test PixelSpacing[end] == ' '
 end
 
 @testset "Writing Sequence" begin


### PR DESCRIPTION
Fix the padding value for IS and DS vrs to `0x20` instead of `0x00` (I missed those two when writing #88)