### PR TITLE
Enforce String length when writing dicom file

### DIFF
--- a/src/DICOM.jl
+++ b/src/DICOM.jl
@@ -616,12 +616,12 @@ function write_element(st::IO, gelt::Tuple{UInt16,UInt16}, data, is_explicit, au
     end
 
     data = isempty(data) ? UInt8[] :
-        vr in ("OB", "OF", "OW", "ST", "LT", "UT") ? data :
-        vr in ("AE", "CS", "TM") ? string_write(data, 16) :
-        # Enforcing the length for this would require knowing the encoding of DICOM file (0x0008, 0x0005)
-        vr in ("SH", "LO", "PN") ? string_write(data, 0) :
+        vr in ("OB", "OF", "OW", "UT") ? data :
+        vr == "ST" ? string_wite(data, 1024) :
+        vr == "LT" ? string_write(data, 10240) :
+        vr in ("SH", "AE", "CS", "TM") ? string_write(data, 16) :
         vr == "DA" ? string_write(data, 8) :
-        vr == "UI" ? string_write(data, 64) :
+        vr == ("LO", "UI") ? string_write(data, 64) :
         vr == "DT" ? string_write(data, 26) :
         vr == "FL" ? convert(Array{Float32,1}, data) :
         vr == "FD" ? convert(Array{Float64,1}, data) :

--- a/src/DICOM.jl
+++ b/src/DICOM.jl
@@ -615,15 +615,10 @@ function write_element(st::IO, gelt::Tuple{UInt16,UInt16}, data, is_explicit, au
         data = [data]
     end
 
-    # For PN, we need to enforce the length of each component
-    if vr == "PN"
-        data = join([string_write(x, 64) for x in split(data, '^')], '^')
-    end
-
     data = isempty(data) ? UInt8[] :
         vr in ("OB", "OF", "OW", "UT") ? data :
-        vr == "PN" ? string_write(data, 0) : # Limits already enforced above
-        vr == "ST" ? string_wite(data, 1024) :
+        vr == "PN" ? string_write(data, 0) : # Enforce maximum length component by component
+        vr == "ST" ? join([string_write(x, 64) for x in split(data, '^')], '^') :
         vr == "LT" ? string_write(data, 10240) :
         vr in ("SH", "AE", "CS", "TM") ? string_write(data, 16) :
         vr == "DA" ? string_write(data, 8) :

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -306,3 +306,14 @@ end
     @test PerformedProtocolSequence[9:12] == "\xff\xff\xff\xff"
     @test PerformedProtocolSequence[end-7:end] == "\xfe\xff\xdd\xe0\x00\x00\x00\x00"
 end
+
+@testset "Integer / Decimal String handling" begin
+    empty_vr_dict = Dict{Tuple{UInt16, UInt16}, String}()
+    # Check IS and DS values are written on 16 bytes (string length)
+    # Using Patient size as an example
+    PatientSize = write_to_string(io -> DICOM.write_element(io, (0x0010, 0x1020), 1.2345678910111213, true, empty_vr_dict))
+    @test PatientSize[1:6] == "\x10\x00\x20\x10DS"
+    @test PatientSize[7:8] == "\x10\x00"
+    @test length(PatientSize) == 24
+    @test PatientSize[9:24] == "1.23456789101112"
+end


### PR DESCRIPTION
At present, "String" lengths are not enforced before writing tags. This can lead to overflows and invalid DICOM.

For example:
`(0x0010, 0x1020) -> 1.2345678910111213` (Patient Size - VR: DS) gets written as is and breaks the rest of the DICOM file.

This PR attempts to fix this in most cases by enforcing the maximum length when writing string values.

The DICOM standard makes the distinction between char and bytes for different VR. When specifying maximum bytes, however, the chartset (ascii subset) matches with the number of chars, so we can collect the `first` chars in both cases.

`PN` needs special care as the limit is enforced by `component`.

I double-checked the maximum lengths by VR but it might be worth someone else checking again.